### PR TITLE
Replace deprecated command flutter pub run with dart run Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,13 +140,13 @@ class HomeScreen extends StatefulWidget {}
 Use the [watch] flag to watch the files' system for edits and rebuild as necessary.
 
 ```terminal                    
-flutter packages pub run build_runner watch                    
+dart run build_runner watch                    
 ```                    
 
 if you want the generator to run one time and exit, use
 
 ```terminal                    
-flutter packages pub run build_runner build                    
+dart run build_runner build                    
 ```                    
 
 #### Add the generated route to your routes list


### PR DESCRIPTION
This fixes a small issue in the documentation The `flutter pub run` command is deprecated and `dart run` command should be used instead.